### PR TITLE
Force storage.file_overwrite to True

### DIFF
--- a/collectfast/management/commands/collectstatic.py
+++ b/collectfast/management/commands/collectstatic.py
@@ -32,12 +32,19 @@ class Command(collectstatic.Command):
         self.tasks = []
         self.etags = {}
         self.storage.preload_metadata = True
+        self.storage.file_overwrite = True
         self.collectfast_enabled = settings.enabled
         if not settings.preload_metadata_enabled:
             warnings.warn(
                 "Collectfast does not work properly without "
                 "`AWS_PRELOAD_METADATA` set to `True`. Overriding "
                 "`storage.preload_metadata` and continuing.")
+
+        if not settings.file_overwrite_enabled:
+            warnings.warn(
+                "Collectfast does not work properly without "
+                "`AWS_S3_FILE_OVERWRITE` set to `True`. Overriding "
+                "`storage.file_overwrite` and continuing.")
 
     def set_options(self, **options):
         """

--- a/collectfast/settings.py
+++ b/collectfast/settings.py
@@ -9,3 +9,5 @@ threads = getattr(settings, "COLLECTFAST_THREADS", False)
 enabled = getattr(settings, "COLLECTFAST_ENABLED", True)
 preload_metadata_enabled = True is getattr(
     settings, 'AWS_PRELOAD_METADATA', False)
+file_overwrite_enabled = True is getattr(
+    settings, 'AWS_S3_FILE_OVERWRITE', False)

--- a/collectfast/tests/test_command.py
+++ b/collectfast/tests/test_command.py
@@ -52,6 +52,18 @@ def test_warn_preload_metadata(case):
 
 
 @test
+@override_setting("file_overwrite_enabled", False)
+@with_bucket
+def test_warn_file_overwrite(case):
+    clean_static_dir()
+    create_static_file()
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        call_collectstatic()
+        case.assertIn('AWS_S3_FILE_OVERWRITE', str(w[0].message))
+
+
+@test
 @override_setting("enabled", False)
 @with_bucket
 def test_collectfast_disabled(case):

--- a/runtests.py
+++ b/runtests.py
@@ -72,6 +72,7 @@ def main():
         "STATICFILES_STORAGE": "storages.backends.s3boto3.S3Boto3Storage",
         "MIDDLEWARE_CLASSES": [],
         "AWS_PRELOAD_METADATA": True,
+        "AWS_S3_FILE_OVERWRITE": True,
         "AWS_STORAGE_BUCKET_NAME": "collectfast",
     })
 


### PR DESCRIPTION
This fixes uploading a static file with the same name twice resulting in
a second file with a randomized suffix in the name, and of course the
first one never to be updated to the newer version.

This is a bit related to #30 and basically has the same fix. It's a bit
surprising that this never was a problem before, but that's probably
because, in contrary to the setting from #30, that default in
django-storages for this setting is the one we need. This also means
that the impact of this change is a lot smaller. It only affects
projects which have manually set this setting to False, most likely to
prevent user uploads from overwriting each other.