### PR TITLE
Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .coverage
 .DS_Store
 .coveragerc.swp
+.tox
+*.egg-info

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,13 @@ sudo: false
 env:
   matrix:
     - TOXENV=py27-django18
-    - TOXENV=py27-django19
     - TOXENV=py27-django110
     - TOXENV=py27-django111
     - TOXENV=py33-django18
     - TOXENV=py34-django18
-    - TOXENV=py34-django19
     - TOXENV=py34-django110
     - TOXENV=py34-django111
     - TOXENV=py35-django18
-    - TOXENV=py35-django19
     - TOXENV=py35-django110
     - TOXENV=py35-django111
     - TOXENV=py36-django111

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,12 +28,3 @@ addons:
       - python3.5
 notifications:
   email: false
-deploy:
-  provider: pypi
-  user: jazzband
-  password:
-    secure: ''
-  on:
-    tags: true
-    distributions: sdist bdist_wheel
-    repo: jazzband/collectfast

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
-envlist = py{27,33,34,35,36}-django{18,19,110,111}
+envlist = py{27,33,34,35,36}-django{18,110,111}
 [testenv]
 deps =
     django18: Django>=1.8,<1.9
-    django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<1.12
     mock==1.3.0


### PR DESCRIPTION
- Remove unused deploy instructions for travis
- Remove Django 1.9 from test matrix since it's no longer supported